### PR TITLE
Add MainMapResolver

### DIFF
--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/EventResolverFactories.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/EventResolverFactories.java
@@ -20,6 +20,7 @@ enum EventResolverFactories {;
                 ExceptionRootCauseResolverFactory.getInstance(),
                 LevelResolverFactory.getInstance(),
                 LoggerResolverFactory.getInstance(),
+                MainMapResolverFactory.getInstance(),
                 MessageResolverFactory.getInstance(),
                 SourceResolverFactory.getInstance(),
                 ThreadResolverFactory.getInstance(),

--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MainMapResolver.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MainMapResolver.java
@@ -1,0 +1,33 @@
+package com.vlkan.log4j2.logstash.layout.resolver;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.lookup.MainMapLookup;
+
+public class MainMapResolver implements EventResolver {
+
+  private final EventResolverContext context;
+
+  private final String key;
+
+  private final MainMapLookup mainMapLookup;
+
+  static String getName() {
+    return "main";
+  }
+
+  MainMapResolver(EventResolverContext context, String key) {
+      this.context = context;
+      this.key = key;
+      this.mainMapLookup = new MainMapLookup();
+  }
+
+  @Override
+  public void resolve(LogEvent logEvent, JsonGenerator jsonGenerator) throws IOException {
+    String value = mainMapLookup.lookup(key);
+    if (value != null) {
+      jsonGenerator.writeObject(value);
+    }
+  }
+}

--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MainMapResolverFactory.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MainMapResolverFactory.java
@@ -1,0 +1,24 @@
+package com.vlkan.log4j2.logstash.layout.resolver;
+
+import org.apache.logging.log4j.core.lookup.MainMapLookup;
+
+public class MainMapResolverFactory implements EventResolverFactory<MainMapResolver> {
+
+  private static final MainMapResolverFactory INSTANCE = new MainMapResolverFactory();
+
+  private MainMapResolverFactory() {}
+
+  static MainMapResolverFactory getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String getName() {
+    return MainMapResolver.getName();
+  }
+
+  @Override
+  public MainMapResolver create(EventResolverContext context, String key) {
+    return new MainMapResolver(context, key);
+  }
+}


### PR DESCRIPTION
When attempting to resolve a layout containing

```{ "app_name":"${main:--name}" }```

I discovered that LogstashLayout doesn't support [org.apache.logging.log4j.core.lookup.MainMapLookup](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/src-html/org/apache/logging/log4j/core/lookup/MainMapLookup.html)
as a fallback. This inspired me to create a MainMapResolver, which
will substitute values when specified like so:

```{ "app_name":"${json:main:--name}" }```

(for key-value based arguments)

or

```{ "app_name":"${json:main:1}" }```

(for positional arguments)