### PR TITLE
Feature/support deferred log4j substitution

### DIFF
--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/EventResolverFactories.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/EventResolverFactories.java
@@ -21,6 +21,7 @@ enum EventResolverFactories {;
                 LevelResolverFactory.getInstance(),
                 LoggerResolverFactory.getInstance(),
                 MainMapResolverFactory.getInstance(),
+                MapResolverFactory.getInstance(),
                 MarkerResolverFactory.getInstance(),
                 MessageResolverFactory.getInstance(),
                 SourceResolverFactory.getInstance(),

--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MapResolver.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MapResolver.java
@@ -1,0 +1,44 @@
+package com.vlkan.log4j2.logstash.layout.resolver;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.lookup.MapLookup;
+import org.apache.logging.log4j.message.MapMessage;
+
+import java.io.IOException;
+
+class MapResolver implements EventResolver {
+
+    private static final MapLookup MAP_LOOKUP = new MapLookup();
+
+    private final EventResolverContext context;
+
+    private final String key;
+
+    static String getName() {
+        return "map";
+    }
+
+    MapResolver(EventResolverContext context, String key) {
+        this.context = context;
+        this.key = key;
+    }
+
+    @Override
+    public void resolve(LogEvent value, JsonGenerator jsonGenerator) throws IOException {
+        if (!(value.getMessage() instanceof MapMessage)) {
+            // If the log4j event is not even a MapMessage then do not even try to perform the map lookup.
+            jsonGenerator.writeNull();
+        }
+
+        // Perform the Map lookup against Log4j
+        String resolvedValue = MAP_LOOKUP.lookup(value, key);
+        boolean valueExcluded = context.isEmptyPropertyExclusionEnabled() && StringUtils.isEmpty(resolvedValue);
+        if (valueExcluded) {
+            jsonGenerator.writeNull();
+        } else {
+            jsonGenerator.writeObject(resolvedValue);
+        }
+    }
+}

--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MapResolver.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MapResolver.java
@@ -26,14 +26,14 @@ class MapResolver implements EventResolver {
     }
 
     @Override
-    public void resolve(LogEvent value, JsonGenerator jsonGenerator) throws IOException {
-        if (!(value.getMessage() instanceof MapMessage)) {
+    public void resolve(LogEvent logEvent, JsonGenerator jsonGenerator) throws IOException {
+        if (!(logEvent.getMessage() instanceof MapMessage)) {
             // If the log4j event is not even a MapMessage then do not even try to perform the map lookup.
             jsonGenerator.writeNull();
         }
 
         // Perform the Map lookup against Log4j
-        String resolvedValue = MAP_LOOKUP.lookup(value, key);
+        String resolvedValue = MAP_LOOKUP.lookup(logEvent, key);
         boolean valueExcluded = context.isEmptyPropertyExclusionEnabled() && StringUtils.isEmpty(resolvedValue);
         if (valueExcluded) {
             jsonGenerator.writeNull();

--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MapResolverFactory.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/resolver/MapResolverFactory.java
@@ -1,0 +1,23 @@
+package com.vlkan.log4j2.logstash.layout.resolver;
+
+public class MapResolverFactory implements EventResolverFactory<MapResolver> {
+
+  private static final MapResolverFactory INSTANCE = new MapResolverFactory();
+
+  private MapResolverFactory() {}
+
+  static MapResolverFactory getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String getName() {
+    return MapResolver.getName();
+  }
+
+  @Override
+  public MapResolver create(EventResolverContext context, String key) {
+    return new MapResolver(context, key);
+  }
+
+}

--- a/layout/src/test/java/com/vlkan/log4j2/logstash/layout/LogstashLayoutTest.java
+++ b/layout/src/test/java/com/vlkan/log4j2/logstash/layout/LogstashLayoutTest.java
@@ -223,6 +223,8 @@ public class LogstashLayoutTest {
         ObjectNode eventTemplateRootNode = JSON_NODE_FACTORY.objectNode();
         eventTemplateRootNode.put("mapValue1", "${map:key1}");
         eventTemplateRootNode.put("mapValue2", "${map:key2}");
+        eventTemplateRootNode.put("nestedLookupEmptyValue", "${map:noExist:-${map:noExist2:-${map:noExist3:-}}}");
+        eventTemplateRootNode.put("nestedLookupStaticValue", "${map:noExist:-${map:noExist2:-${map:noExist3:-Static Value}}}");
         String eventTemplate = eventTemplateRootNode.toString();
 
         // Create the layout.
@@ -251,6 +253,8 @@ public class LogstashLayoutTest {
         JsonNode rootNode = OBJECT_MAPPER.readTree(serializedLogEvent);
         assertThat(point(rootNode, "mapValue1").asText()).isEqualTo("val1");
         assertThat(point(rootNode, "mapValue2").asText()).isEqualTo("val2");
+        assertThat(point(rootNode, "nestedLookupEmptyValue").isMissingNode());
+        assertThat(point(rootNode, "nestedLookupStaticValue").asText()).isEqualTo("Static Value");
     }
 
 

--- a/layout/src/test/java/com/vlkan/log4j2/logstash/layout/LogstashLayoutTest.java
+++ b/layout/src/test/java/com/vlkan/log4j2/logstash/layout/LogstashLayoutTest.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
 import org.apache.logging.log4j.core.lookup.MainMapLookup;
+import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -214,6 +215,44 @@ public class LogstashLayoutTest {
         assertThat(point(rootNode, staticFieldName).asText()).isEqualTo(staticFieldValue);
 
     }
+
+    @Test
+    public void test_log4j_deferred_runtime_resolver_map_message() throws Exception {
+
+        // Create the event template.
+        ObjectNode eventTemplateRootNode = JSON_NODE_FACTORY.objectNode();
+        eventTemplateRootNode.put("mapValue1", "${map:key1}");
+        eventTemplateRootNode.put("mapValue2", "${map:key2}");
+        String eventTemplate = eventTemplateRootNode.toString();
+
+        // Create the layout.
+        BuiltConfiguration configuration = ConfigurationBuilderFactory.newConfigurationBuilder().build();
+        String timeZoneId = TimeZone.getTimeZone("Europe/Malta").getID();
+        LogstashLayout layout = LogstashLayout
+                .newBuilder()
+                .setConfiguration(configuration)
+                .setEventTemplate(eventTemplate)
+                .setTimeZoneId(timeZoneId)
+                .build();
+
+        // Create the MapMessage log event.
+        MapMessage mapMessage = new MapMessage().with("key1", "val1").with("key2", "val2");
+        LogEvent logEvent = Log4jLogEvent
+                .newBuilder()
+                .setLoggerName(LogstashLayoutTest.class.getSimpleName())
+                .setLevel(Level.INFO)
+                .setMessage(mapMessage)
+                .setTimeMillis(System.currentTimeMillis())
+                .build();
+
+
+        // Check the serialized event.
+        String serializedLogEvent = layout.toSerializable(logEvent);
+        JsonNode rootNode = OBJECT_MAPPER.readTree(serializedLogEvent);
+        assertThat(point(rootNode, "mapValue1").asText()).isEqualTo("val1");
+        assertThat(point(rootNode, "mapValue2").asText()).isEqualTo("val2");
+    }
+
 
     @Test
     public void test_property_injection() throws Exception {
@@ -517,6 +556,39 @@ public class LogstashLayoutTest {
         assertThat(point(rootNode, mdcFieldName, mdcPatternMismatchedKey)).isInstanceOf(MissingNode.class);
         assertThat(point(rootNode, mdcDirectlyAccessedNullPropertyKey)).isInstanceOf(MissingNode.class);
 
+    }
+
+    @Test
+    public void test_mapResolver() throws IOException {
+        MapMessage message = new MapMessage().with("key1", "val1");
+        LogEvent logEvent = Log4jLogEvent
+                .newBuilder()
+                .setLoggerName(LogstashLayoutTest.class.getSimpleName())
+                .setLevel(Level.INFO)
+                .setMessage(message)
+                .build();
+
+
+        // Create event template node with empty property and MDC fields.
+        ObjectNode eventTemplateRootNode = JSON_NODE_FACTORY.objectNode();
+        eventTemplateRootNode.put("mapValue1", "${json:map:key1}");
+        eventTemplateRootNode.put("mapValue2", "${json:map:noExist}");
+        String eventTemplate = eventTemplateRootNode.toString();
+
+        // Create the layout.
+        BuiltConfiguration configuration = ConfigurationBuilderFactory.newConfigurationBuilder().build();
+        LogstashLayout layout = LogstashLayout
+                .newBuilder()
+                .setConfiguration(configuration)
+                .setEventTemplate(eventTemplate)
+                .setEmptyPropertyExclusionEnabled(true)
+                .build();
+
+        // Check serialized event.
+        String serializedLogEvent = layout.toSerializable(logEvent);
+        JsonNode rootNode = OBJECT_MAPPER.readTree(serializedLogEvent);
+        assertThat(point(rootNode, "mapValue1").asText()).isEqualTo("val1");
+        assertThat(point(rootNode, "mapValue2").isMissingNode()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
This PR adds two features:

- A dedicated MapLookup EventResolver was added to support `${json:map:xxx}`.
- Added a generic Log4j fallback option when the template includes a non-${json:} value. Hopefully this reduces the need to keep this library in sync with the substitutors that Log4j may add in the future.

Tests were also added for the above scenarios as well.

Enjoy :)