### PR TITLE
use UTF-8 charset for whole stacktrace resolver

### DIFF
--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/LogstashLayout.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/LogstashLayout.java
@@ -38,7 +38,7 @@ import java.util.TimeZone;
         printObject = true)
 public class LogstashLayout implements Layout<String> {
 
-    private static final Charset CHARSET = StandardCharsets.UTF_8;
+    public static final Charset CHARSET = StandardCharsets.UTF_8;
 
     private static final String CONTENT_TYPE = "application/json; charset=" + CHARSET;
 

--- a/layout/src/main/java/com/vlkan/log4j2/logstash/layout/util/Throwables.java
+++ b/layout/src/main/java/com/vlkan/log4j2/logstash/layout/util/Throwables.java
@@ -1,5 +1,7 @@
 package com.vlkan.log4j2.logstash.layout.util;
 
+import com.vlkan.log4j2.logstash.layout.LogstashLayout;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
@@ -9,12 +11,10 @@ public enum Throwables {;
 
     public static String serializeStackTrace(Throwable exception) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (PrintStream printStream = new PrintStream(outputStream)) {
+        try (PrintStream printStream = new PrintStream(outputStream, false, LogstashLayout.CHARSET.name())) {
             exception.printStackTrace(printStream);
-        }
-        try {
             return outputStream.toString(StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException error) {
+        }  catch (UnsupportedEncodingException error) {
             throw new RuntimeException("failed converting the stack trace to string", error);
         }
     }


### PR DESCRIPTION
Before this change, platform encoding was used for stacktrace while
UTF-8 charset was used for other resolvers (exception_message for
example).