### PR TITLE
specifying the --release javac compiler option to correctly compile for java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
+        <maven.compiler.release>8</maven.compiler.release>
 
         <!-- library versions -->
         <assertj-core.version>3.18.0</assertj-core.version>
@@ -172,6 +173,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <release>${maven.compiler.release}</release>
                     <compilerArgs>
                         <arg>-Xlint:unchecked</arg>
                     </compilerArgs>


### PR DESCRIPTION
specifying the --release javac compiler option to correctly compile for java8