### PR TITLE
Update Log4j version to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.vlkan.log4j2</groupId>
     <artifactId>log4j2-logstash-layout-parent</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -74,7 +74,7 @@
         <jackson.version>[2.10.2,)</jackson.version>
         <jmh.version>1.26</jmh.version>
         <junit.version>4.13.1</junit.version>
-        <log4j2.version>2.13.3</log4j2.version>
+        <log4j2.version>2.16.0</log4j2.version>
         <mockito.version>3.6.0</mockito.version>
 
         <!-- plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.vlkan.log4j2</groupId>
     <artifactId>log4j2-logstash-layout-parent</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
https://www.kaspersky.co.uk/blog/log4shell-critical-vulnerability-in-apache-log4j/23933/